### PR TITLE
Reduce allocations during classification

### DIFF
--- a/VSColorOutput/Output/BuildEvents/BuildEvents.cs
+++ b/VSColorOutput/Output/BuildEvents/BuildEvents.cs
@@ -24,7 +24,6 @@ namespace VSColorOutput.Output.BuildEvents
         private int _initialized;
         private DateTime _buildStartTime;
         private List<string> _projectsBuildReport;
-        private CultureInfo _cultureInfo = CultureInfo.InvariantCulture;
 
         public bool StopOnBuildErrorEnabled { get; set; }
         public bool ShowElapsedBuildTimeEnabled { get; set; }
@@ -78,7 +77,6 @@ namespace VSColorOutput.Output.BuildEvents
         private void LoadSettings()
         {
             var settings = Settings.Load();
-            _cultureInfo = settings.FormatTimeInSystemLocale ? CultureInfo.CurrentCulture : CultureInfo.InvariantCulture;
             StopOnBuildErrorEnabled = settings.EnableStopOnBuildError;
             ShowElapsedBuildTimeEnabled = settings.ShowElapsedBuildTime;
             ShowBuildReport = settings.ShowBuildReport;

--- a/VSColorOutput/Output/GCCErrorList/GCCErrorListOutputClassifier.cs
+++ b/VSColorOutput/Output/GCCErrorList/GCCErrorListOutputClassifier.cs
@@ -37,12 +37,11 @@ namespace VSColorOutput.Output.GCCErrorList
         {
             try
             {
-                var spans = new List<ClassificationSpan>();
                 var snapshot = span.Snapshot;
-                if (snapshot == null || snapshot.Length == 0) return spans;
+                if (snapshot == null || snapshot.Length == 0) return Array.Empty<ClassificationSpan>();
                 if (_classifiers == null) UpdateClassifiers();
 
-                var classifiers = _classifiers ?? new List<Classifier>();
+                var classifiers = _classifiers;
                 var start = span.Start.GetContainingLine().LineNumber;
                 var end = (span.End - 1).GetContainingLine().LineNumber;
                 for (var i = start; i <= end; i++)
@@ -72,22 +71,22 @@ namespace VSColorOutput.Output.GCCErrorList
 
                     }
                 }
-                return spans;
+                return Array.Empty<ClassificationSpan>();
             }
             catch (FormatException)
             {
                 // eat it.
-                return new List<ClassificationSpan>();
+                return Array.Empty<ClassificationSpan>();
             }
             catch (RegexMatchTimeoutException)
             {
                 // eat it.
-                return new List<ClassificationSpan>();
+                return Array.Empty<ClassificationSpan>();
             }
             catch (NullReferenceException)
             {
                 // eat it.    
-                return new List<ClassificationSpan>();
+                return Array.Empty<ClassificationSpan>();
             }
             catch (Exception ex)
             {

--- a/VSColorOutput/VSColorOutput.csproj
+++ b/VSColorOutput/VSColorOutput.csproj
@@ -26,6 +26,7 @@
     <StartAction>Program</StartAction>
     <StartProgram Condition="'$(DevEnvDir)' != ''">$(DevEnvDir)devenv.exe</StartProgram>
     <StartArguments>/rootsuffix Exp</StartArguments>
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Avoids allocating empty lists by using singleton empty arrays where possible.

When a lot of output is produced, these savings can add up and help reduce GC pressure.