### PR TITLE
More classifiers

### DIFF
--- a/VSColorOutput.Tests/OutputClassifierTests.cs
+++ b/VSColorOutput.Tests/OutputClassifierTests.cs
@@ -55,6 +55,12 @@ namespace Tests
         [DataRow(" 0 Error(s)", ClassificationTypeDefinitions.BuildHead)]
         [DataRow("Could not find file", ClassificationTypeDefinitions.LogError)]
         [DataRow("warning CS0168: The variable \'exception\'", ClassificationTypeDefinitions.LogWarn)]
+        [DataRow("[11:15:27.531394] info: some mundane information message", ClassificationTypeDefinitions.LogInfo)]
+        [DataRow("[11:15:27.531394] warn: a message to notify a user", ClassificationTypeDefinitions.LogWarn)]
+        [DataRow("[11:15:27.531394] trce: random trace message", ClassificationTypeDefinitions.BuildText)]
+        [DataRow("[11:15:27.531394] dbug: random debug message", ClassificationTypeDefinitions.BuildText)]
+        [DataRow("[11:15:27.531394] fail: failure description", ClassificationTypeDefinitions.LogError)]
+        [DataRow("[11:15:27.531394] crit: failure description", ClassificationTypeDefinitions.LogError)]
         [DataTestMethod]
         public void GetClassificationSpansFromSnapShot(string pattern, string classification)
         {

--- a/VSColorOutput/State/Settings.cs
+++ b/VSColorOutput/State/Settings.cs
@@ -212,7 +212,7 @@ namespace VSColorOutput.State
                 },
                 new RegExClassification
                 {
-                    RegExPattern       = @"(\W|^)^(?!.*warning\s(BC|CS|CA)\d+:).*((?<!/)error|fail|failed|exception)[^\w\.\-\+]",
+                    RegExPattern       = @"(\W|^)^(?!.*warning\s(BC|CS|CA)\d+:).*((?<!/)error|fail|crit|failed|exception)[^\w\.\-\+]",
                     ClassificationType = ClassificationTypes.LogError,
                     IgnoreCase         = true
                 },
@@ -230,13 +230,13 @@ namespace VSColorOutput.State
                 },
                 new RegExClassification
                 {
-                    RegExPattern       = @"(\W|^)warning\W",
+                    RegExPattern       = @"(\W|^)(warning|warn)\W",
                     ClassificationType = ClassificationTypes.LogWarning,
                     IgnoreCase         = true
                 },
                 new RegExClassification
                 {
-                    RegExPattern       = @"(\W|^)information\W",
+                    RegExPattern       = @"(\W|^)(information|info)\W",
                     ClassificationType = ClassificationTypes.LogInformation,
                     IgnoreCase         = true
                 },


### PR DESCRIPTION
Add classifiers to match logs produced by SimpleConsoleFormatter https://github.com/dotnet/runtime/blob/6a889d23/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatter.cs#L142-L154

The Windows Forms designer in Visual Studio emits diagnostics logs, and I'm making sure these logs are correctly categorised (and prefixed). The prefix strategy is the same as employed by [`SimpleConsoleFormatter`](https://github.com/dotnet/runtime/blob/6a889d23/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatter.cs#L142-L154).
This will help developers who build Windows Forms .NET applications (and obviously use your wonderful extension) to read the diagnostics output.

Before:
![image](https://user-images.githubusercontent.com/4403806/162346068-ac445adc-038c-42f0-9de1-eae58729e9a9.png)
After:
![image](https://user-images.githubusercontent.com/4403806/162345994-b59e4ad6-6ff1-4792-82e8-8f1aab5bd348.png)

I've tested it manually by applying the changes in the installed extension, and then applying the changes to the code.