### PR TITLE
Complementatry fix for issue #22 (taking project number prefix into account)

### DIFF
--- a/VSColorOutput/State/Settings.cs
+++ b/VSColorOutput/State/Settings.cs
@@ -194,13 +194,13 @@ namespace VSColorOutput.State
                 },
                 new RegExClassification
                 {
-                    RegExPattern       = @"^\s*0 error\(s\)\s*$",
+                    RegExPattern       = @"^(\d+>)?\s*0 error\(s\)\s*$",
                     ClassificationType = ClassificationTypes.BuildHead,
                     IgnoreCase         = true
                 },
                 new RegExClassification
                 {
-                    RegExPattern       = @"^\s*0 warning\(s\)\s*$",
+                    RegExPattern       = @"^(\d+>)?\s*0 warning\(s\)\s*$",
                     ClassificationType = ClassificationTypes.BuildHead,
                     IgnoreCase         = true
                 },


### PR DESCRIPTION
The default regex for "0 Error(s)" and "0 Warning(s)" don't work when lines start with a project number prefix.
Ex:
2>    0 Warning(s)
2>    0 Error(s)

This fix has been tested by building VSColorOutput.sln with VS 2022 Community.