### PR TITLE
Changed default regex ".*[t|c]sc\.exe.*" to "[t|c]sc\.exe"

### DIFF
--- a/VSColorOutput/State/Settings.cs
+++ b/VSColorOutput/State/Settings.cs
@@ -193,7 +193,7 @@ namespace VSColorOutput.State
                 },
                 new RegExClassification
                 {
-                    RegExPattern       = @".*[t|c]sc\.exe.*",
+                    RegExPattern       = @"[t|c]sc\.exe",
                     ClassificationType = ClassificationTypes.BuildText,
                     IgnoreCase         = false
                 },


### PR DESCRIPTION
The previous version was slow with long strings. Both versions should match the same strings.

Fixes #10.